### PR TITLE
"confirm registraton" key should be omitted.

### DIFF
--- a/modules/auth/lang/en.json
+++ b/modules/auth/lang/en.json
@@ -33,7 +33,6 @@
 	"Confirm Registration": "Confirm Registration",
 	"Confirm your registration": "Confirm your registration",
 	"Confirm registration": "Confirm registration",
-	"Confirm registraton": "Confirm registraton",
 	"Loading confirmation data from server, please wait...": "Loading confirmation data from server, please wait...",
 	"Your e-mail has been confirmed and the account has been activated successfully.": "Your e-mail has been confirmed and the account has been activated successfully.",
 	"Could not activate your account. Please check your link or try again in several moments.": "Could not activate your account. Please check your link or try again in several moments.",


### PR DESCRIPTION
There's a typo in "confirm registraton" key, and since there's another key with a proper name ("confirm registration") we are able to omit the former with no fuss.